### PR TITLE
Refactor: Relocate clipboard security menu and enhance module settings

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -88,13 +88,32 @@ DEFAULT_MODULES_CONFIG = {
     'mermaid_modify_clipboard': False, # This likely refers to modifying clipboard content, not URL copying or browser opening
     'mermaid_copy_url': False, # Default for copying URL specifically for Mermaid
     'mermaid_open_in_browser': True, # Default for opening browser for Mermaid
+    'mermaid_theme': "default", # Options: "default", "dark", "forest", "neutral"
     'history_enabled': True,
-    # drawio settings are typically handled similarly, ensuring drawio_copy_url and drawio_open_in_browser have defaults
-    # (often True by default in their respective get_config_value calls if not found)
-    # For consistency, we can list them here if desired, though the current structure might rely on get_config_value defaults.
-    # 'drawio_copy_url': True, # Example if we wanted to explicitly define all module sub-settings here
-    # 'drawio_open_in_browser': True # Example
+    # Draw.io specific URL parameters
+    'drawio_copy_url': True, # Existing setting, kept for clarity
+    'drawio_open_in_browser': True, # Existing setting, kept for clarity
+    'drawio_lightbox': True,
+    'drawio_edit_mode': "_blank", # e.g., "_blank", "local", "device"
+    'drawio_layers': True,
+    'drawio_nav': True,
 }
+
+# Mermaid themes for menu
+MERMAID_THEMES = {
+    "Default": "default",
+    "Dark": "dark",
+    "Forest": "forest",
+    "Neutral": "neutral"
+}
+
+# Draw.io edit modes for menu
+DRAWIO_EDIT_MODES = {
+    "New Tab (_blank)": "_blank",
+    "Local": "local", # Assuming "local" is a valid option, placeholder
+    "Device": "device"  # Assuming "device" is a valid option, placeholder
+}
+
 
 # Complete default configuration
 DEFAULT_CONFIG = {

--- a/modules/code_formatter_module.py
+++ b/modules/code_formatter_module.py
@@ -119,9 +119,13 @@ def process(clipboard_content, config=None):
                 else:
                     log_event("Code already properly formatted")
             else:
-                # Read-only mode: just notify about code detection
-                show_notification("Code Detected", "Code detected (read-only mode)", "")
-                logger.info("[blue]Code detected but clipboard modification disabled for safety[/blue]")
+                # Modification is disabled. Show an alert/notification.
+                logger.info("[yellow]Code detected but module is not allowed to modify clipboard. Alerting user.[/yellow]")
+                show_notification(
+                    "Clipboard Access Denied",
+                    "Code Formatter Module attempted to process clipboard content.",
+                    "Modification is disabled. You can enable it in Preferences > Security Settings > Clipboard Modification."
+                )
                 return False  # Don't modify clipboard
                 
     return False

--- a/modules/markdown_module.py
+++ b/modules/markdown_module.py
@@ -98,9 +98,13 @@ def process(clipboard_content, config=None) -> bool:
                         logger.error(f"[bold red]Unexpected error during RTF copy:[/bold red] {e}")
                         return False
             else:
-                # Read-only mode: just notify about markdown detection
-                show_notification("Markdown Detected", "Markdown detected (read-only mode)", "")
-                logger.info("[blue]Markdown detected but clipboard modification disabled[/blue]")
+                # Modification is disabled. Show an alert/notification.
+                logger.info("[yellow]Markdown detected but module is not allowed to modify clipboard. Alerting user.[/yellow]")
+                show_notification(
+                    "Clipboard Access Denied",
+                    "Markdown Module attempted to process clipboard content.",
+                    "Modification is disabled. You can enable it in Preferences > Security Settings > Clipboard Modification."
+                )
                 return False  # Don't modify clipboard
 
         return False    # Indicate that content was not processed

--- a/modules/mermaid_module.py
+++ b/modules/mermaid_module.py
@@ -60,11 +60,15 @@ def is_mermaid_code(text):
         log_error(f"Error checking Mermaid code: {str(e)}")
         return False
 
-def create_mermaid_url(mermaid_code):
-    """Create Mermaid Live Editor URL using JSON and base64url encoding"""
+def create_mermaid_url(mermaid_code, theme="default"):
+    """Create Mermaid Live Editor URL using JSON and base64url encoding, including theme."""
     try:
         # Create the payload structure
-        data = {"code": mermaid_code, "mermaid": {}}
+        mermaid_config = {}
+        if theme and theme.lower() != "default":
+            mermaid_config["theme"] = theme
+
+        data = {"code": mermaid_code, "mermaid": mermaid_config}
         
         # Convert to JSON with minimal whitespace
         json_str = json.dumps(data, separators=(',', ':'))
@@ -86,7 +90,11 @@ def create_mermaid_url(mermaid_code):
 def launch_mermaid_chart(mermaid_code, config=None):
     """Launch the Mermaid diagram in browser and optionally copy URL to clipboard"""
     try:
-        url = create_mermaid_url(mermaid_code)
+        mermaid_theme = "default"
+        if config:
+            mermaid_theme = config.get('mermaid_theme', "default")
+
+        url = create_mermaid_url(mermaid_code, theme=mermaid_theme)
         if not url:
             return False
 


### PR DESCRIPTION
- Moved 'Clipboard Modification' submenu from 'Module Settings' to 'Security Settings' in Preferences for better logical grouping.
- Updated notifications for Markdown and Code Formatter modules to be more explicit when clipboard modification is attempted but disallowed by settings, guiding users to the correct preference location.

- Added new configurable settings for Draw.io module:
  - Individual menu controls for URL parameters: Lightbox, Edit Mode, Layers, and Navigation.
  - Draw.io module now dynamically constructs URLs based on these settings.

- Added new configurable setting for Mermaid module:
  - Menu option to select editor theme (Default, Dark, Forest, Neutral).
  - Mermaid module now includes the selected theme in the generated URL.

- Updated constants.py with new default configurations and menu data.
- Modified menu_bar_app.py to include UI elements and callbacks for these new settings.