### PR TITLE
Feat: Relocate clipboard menu, enhance alerts & module settings

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -97,6 +97,9 @@ DEFAULT_MODULES_CONFIG = {
     'drawio_edit_mode': "_blank", # e.g., "_blank", "local", "device"
     'drawio_layers': True,
     'drawio_nav': True,
+    'drawio_appearance': "auto",  # "auto", "light", "dark"
+    'drawio_border_color': "none", # "none" or hex color e.g., "FF0000"
+    'drawio_links': "auto",       # "auto", "blank" (for new tab), "self" (for same tab)
 }
 
 # Mermaid themes for menu
@@ -110,8 +113,22 @@ MERMAID_THEMES = {
 # Draw.io edit modes for menu
 DRAWIO_EDIT_MODES = {
     "New Tab (_blank)": "_blank",
-    "Local": "local", # Assuming "local" is a valid option, placeholder
-    "Device": "device"  # Assuming "device" is a valid option, placeholder
+    # "Local": "local", # diagrams.net doc does not explicitly list "local" for #R URLs
+    # "Device": "device" # diagrams.net doc does not explicitly list "device" for #R URLs
+}
+
+# Draw.io appearance modes for menu
+DRAWIO_APPEARANCE_MODES = {
+    "Automatic": "auto",
+    "Light": "light",
+    "Dark": "dark"
+}
+
+# Draw.io link behaviors for menu
+DRAWIO_LINKS_MODES = {
+    "Automatic": "auto", # Default browser behavior
+    "Open in New Tab": "blank",
+    "Open in Same Tab": "self"
 }
 
 


### PR DESCRIPTION
- Core:
  - Relocated 'Clipboard Modification' submenu from 'Module Settings' to 'Security Settings' in Preferences for better logical grouping.
  - Updated notifications for Markdown and Code Formatter modules to be more explicit when clipboard modification is attempted but disallowed by settings, guiding users to the correct preference location.

- Draw.io Module:
  - Added comprehensive configurable URL parameters:
    - Lightbox (toggle)
    - Edit Mode (submenu)
    - Layers Enabled (toggle)
    - Navigation Enabled (toggle)
    - Appearance (submenu: Auto/Light/Dark)
    - Link Behavior (submenu: Auto/New Tab/Same Tab)
    - Border Color (text input, accepts 'none' or hex)
  - Module now dynamically constructs URLs based on these settings.

- Mermaid Module:
  - Added menu option to select editor theme (Default, Dark, Forest, Neutral).
  - Module now includes the selected theme in the generated URL.

- Configuration & UI:
  - Updated constants.py with new default configurations and helper dictionaries for menu options.
  - Updated menu_bar_app.py to include UI elements (submenus, toggles, text input) and corresponding callback functions for all new settings.
  - Ensured service restart occurs after changing relevant module settings.