### PR TITLE
Fix: Align menu bar structure with documentation & finalize settings

### DIFF
--- a/menu_bar_app.py
+++ b/menu_bar_app.py
@@ -489,19 +489,26 @@ class ClipboardMonitorMenuBar(rumps.App):
             rumps.notification("Error", "Failed to update Mermaid theme", "Could not save configuration.")
  
     def _build_main_menu(self):
-        """Build the main menu structure."""
+        """Build the main menu structure to match docs/MENU_ORGANIZATION.md."""
+        # Section 1: Status & Service Control
         self.menu.add(self.status_item)
         self.menu.add(rumps.separator)
-        self.menu.add(self.pause_toggle)  # Add the pause toggle
+        self.menu.add(self.pause_toggle)
         self.menu.add(self.service_control_menu)
-        self.menu.add(self.logs_menu)
         self.menu.add(rumps.separator)
+
+        # Section 2: History & Modules (as per docs: History items first, then Modules)
+        self.menu.add(self.recent_history_menu)
+        self.menu.add(self.history_menu)
         self.menu.add(self.module_menu)
         self.menu.add(rumps.separator)
-        self.menu.add(self.recent_history_menu)  # Add Recent Clipboard Items just before history
-        self.menu.add(self.history_menu)
+
+        # Section 3: Preferences
         self.menu.add(self.prefs_menu)
         self.menu.add(rumps.separator)
+
+        # Section 4: Application (Logs then Quit)
+        self.menu.add(self.logs_menu)
         self.menu.add(self.quit_item)
     
     def load_module_config(self):


### PR DESCRIPTION
- Corrected the main menu item order in `menu_bar_app.py` to match the structure described in `docs/MENU_ORGANIZATION.md`. This includes:
  - Status & Service Control
  - History & Modules (History items now correctly appear before Modules)
  - Preferences
  - Application (Logs, Quit - Logs moved to this section)

- This commit also includes the previously implemented features:
  - Relocation of 'Clipboard Modification' menu to 'Security Settings'.
  - Enhanced alerts for modules attempting clipboard modification when restricted.
  - New configurable settings for Draw.io module (URL parameters: Lightbox, Edit Mode, Layers, Nav, Appearance, Links, Border Color).
  - New configurable 'Editor Theme' for Mermaid module.
  - Updated `constants.py`, `modules/drawio_module.py`, `modules/mermaid_module.py`, and `menu_bar_app.py` for these settings.
  - Comprehensive updates to documentation (`readme.md`, `MENU_ORGANIZATION.md`, `MODULE_DEVELOPMENT.md`, `LATEST_UPDATES.md`) to reflect all these changes.